### PR TITLE
Release v0.3.0 — Export Decorators + Storage Drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@nestbolt/excel` will be documented in this file.
 
-## Unreleased
+## v0.3.0 — Export Decorators + Storage Drivers
 
 ### Export Decorators
 

--- a/README.md
+++ b/README.md
@@ -1012,7 +1012,7 @@ Inject `ExcelService` and call its methods:
 | `defaultType`    | `'xlsx' \| 'csv'`             | `'xlsx'`    | Fallback type when extension is unrecognised   |
 | `tempDirectory`  | `string`                      | OS temp dir | Directory for temporary files                  |
 | `disks`          | `Record<string, DiskConfig>`  | —           | Named storage backends (see Storage Drivers)   |
-| `defaultDisk`    | `string`                      | —           | Default disk name used when `disk` is omitted  |
+| `defaultDisk`    | `string`                      | `'local'`   | Default disk name used when `disk` is omitted  |
 | `csv.delimiter`  | `string`                      | `','`       | CSV column delimiter                           |
 | `csv.quoteChar`  | `string`                      | `'"'`       | CSV quote character                            |
 | `csv.lineEnding` | `string`                      | `'\n'`      | CSV line ending                                |

--- a/README.md
+++ b/README.md
@@ -314,12 +314,12 @@ class EmployeeEntity extends BaseEntity {
 
 ### Service Methods (Decorator API)
 
-| Method                                                    | Returns               | Description                          |
-| --------------------------------------------------------- | --------------------- | ------------------------------------ |
-| `downloadFromEntity(entityClass, data, filename, type?)`  | `ExcelDownloadResult` | Buffer + filename + content type     |
-| `downloadFromEntityAsStream(entityClass, data, filename, type?)` | `StreamableFile` | NestJS StreamableFile for controllers |
-| `storeFromEntity(entityClass, data, filePath, type?)`     | `void`                | Write to a local file                |
-| `rawFromEntity(entityClass, data, type)`                  | `Buffer`              | Raw file buffer                      |
+| Method                                                              | Returns               | Description                          |
+| ------------------------------------------------------------------- | --------------------- | ------------------------------------ |
+| `downloadFromEntity(entityClass, data, filename, type?)`            | `ExcelDownloadResult` | Buffer + filename + content type     |
+| `downloadFromEntityAsStream(entityClass, data, filename, type?)`    | `StreamableFile`      | NestJS StreamableFile for controllers |
+| `storeFromEntity(entityClass, data, filePath, type?, disk?)`        | `void`                | Write to storage (default or named disk) |
+| `rawFromEntity(entityClass, data, type)`                            | `Buffer`              | Raw file buffer                      |
 
 ---
 
@@ -980,42 +980,44 @@ Inject `ExcelService` and call its methods:
 
 ### Export Methods (Concern-based)
 
-| Method                                          | Returns               | Description                                                  |
-| ----------------------------------------------- | --------------------- | ------------------------------------------------------------ |
-| `download(exportable, filename, type?)`         | `ExcelDownloadResult` | Returns buffer + filename + content type                     |
-| `downloadAsStream(exportable, filename, type?)` | `StreamableFile`      | Returns a NestJS StreamableFile for direct controller return |
-| `store(exportable, filePath, type?)`            | `void`                | Writes the export to a local file                            |
-| `raw(exportable, type)`                         | `Buffer`              | Returns the raw file buffer                                  |
+| Method                                                | Returns               | Description                                                  |
+| ----------------------------------------------------- | --------------------- | ------------------------------------------------------------ |
+| `download(exportable, filename, type?)`               | `ExcelDownloadResult` | Returns buffer + filename + content type                     |
+| `downloadAsStream(exportable, filename, type?)`       | `StreamableFile`      | Returns a NestJS StreamableFile for direct controller return |
+| `store(exportable, filePath, type?, disk?)`            | `void`                | Writes the export to storage (default or named disk)         |
+| `raw(exportable, type)`                               | `Buffer`              | Returns the raw file buffer                                  |
 
 ### Export Methods (Decorator-based)
 
-| Method                                                    | Returns               | Description                          |
-| --------------------------------------------------------- | --------------------- | ------------------------------------ |
-| `downloadFromEntity(entityClass, data, filename, type?)`  | `ExcelDownloadResult` | Buffer + filename + content type     |
-| `downloadFromEntityAsStream(entityClass, data, filename, type?)` | `StreamableFile` | NestJS StreamableFile for controllers |
-| `storeFromEntity(entityClass, data, filePath, type?)`     | `void`                | Write to a local file                |
-| `rawFromEntity(entityClass, data, type)`                  | `Buffer`              | Raw file buffer                      |
+| Method                                                              | Returns               | Description                          |
+| ------------------------------------------------------------------- | --------------------- | ------------------------------------ |
+| `downloadFromEntity(entityClass, data, filename, type?)`            | `ExcelDownloadResult` | Buffer + filename + content type     |
+| `downloadFromEntityAsStream(entityClass, data, filename, type?)`    | `StreamableFile`      | NestJS StreamableFile for controllers |
+| `storeFromEntity(entityClass, data, filePath, type?, disk?)`        | `void`                | Write to storage (default or named disk) |
+| `rawFromEntity(entityClass, data, type)`                            | `Buffer`              | Raw file buffer                      |
 
 ### Import Methods
 
-| Method                                              | Returns                      | Description                                  |
-| --------------------------------------------------- | ---------------------------- | -------------------------------------------- |
-| `import(importable, filePath, type?)`               | `ImportResult`               | Read and process a local file                |
-| `importFromBuffer(importable, buffer, type?)`       | `ImportResult`               | Read and process a buffer                    |
-| `toArray(filePath, type?)`                          | `any[][]`                    | Shorthand: returns raw 2D array              |
-| `toCollection(filePath, type?)`                     | `Record<string, any>[]`      | Shorthand: returns objects using row 1 as headings |
+| Method                                              | Returns                      | Description                                          |
+| --------------------------------------------------- | ---------------------------- | ---------------------------------------------------- |
+| `import(importable, filePath, type?, disk?)`        | `ImportResult`               | Read and process a file from storage                 |
+| `importFromBuffer(importable, buffer, type?)`       | `ImportResult`               | Read and process a buffer                            |
+| `toArray(filePath, type?, disk?)`                   | `any[][]`                    | Shorthand: returns raw 2D array                      |
+| `toCollection(filePath, type?, disk?)`              | `Record<string, any>[]`      | Shorthand: returns objects using row 1 as headings   |
 
 ## Configuration Options
 
-| Option           | Type              | Default     | Description                                  |
-| ---------------- | ----------------- | ----------- | -------------------------------------------- |
-| `defaultType`    | `'xlsx' \| 'csv'` | `'xlsx'`    | Fallback type when extension is unrecognised |
-| `tempDirectory`  | `string`          | OS temp dir | Directory for temporary files                |
-| `csv.delimiter`  | `string`          | `','`       | CSV column delimiter                         |
-| `csv.quoteChar`  | `string`          | `'"'`       | CSV quote character                          |
-| `csv.lineEnding` | `string`          | `'\n'`      | CSV line ending                              |
-| `csv.useBom`     | `boolean`         | `false`     | Prepend UTF-8 BOM                            |
-| `csv.encoding`   | `BufferEncoding`  | `'utf-8'`   | Output encoding                              |
+| Option           | Type                          | Default     | Description                                    |
+| ---------------- | ----------------------------- | ----------- | ---------------------------------------------- |
+| `defaultType`    | `'xlsx' \| 'csv'`             | `'xlsx'`    | Fallback type when extension is unrecognised   |
+| `tempDirectory`  | `string`                      | OS temp dir | Directory for temporary files                  |
+| `disks`          | `Record<string, DiskConfig>`  | —           | Named storage backends (see Storage Drivers)   |
+| `defaultDisk`    | `string`                      | —           | Default disk name used when `disk` is omitted  |
+| `csv.delimiter`  | `string`                      | `','`       | CSV column delimiter                           |
+| `csv.quoteChar`  | `string`                      | `'"'`       | CSV quote character                            |
+| `csv.lineEnding` | `string`                      | `'\n'`      | CSV line ending                                |
+| `csv.useBom`     | `boolean`                     | `false`     | Prepend UTF-8 BOM                              |
+| `csv.encoding`   | `BufferEncoding`              | `'utf-8'`   | Output encoding                                |
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestbolt/excel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packageManager": "pnpm@9.15.4",
   "description": "Supercharged Excel and CSV exports and imports for NestJS applications. Effortlessly create, download, and import spreadsheets with powerful features and seamless integration.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps version from `0.2.0` → `0.3.0`
- Moves changelog entries from **Unreleased** to **v0.3.0**
- Updates README service method tables with `disk` parameter
- Adds `disks` and `defaultDisk` to the Configuration Options table

## What's in v0.3.0

### Export Decorators
- `@Exportable()`, `@ExportColumn()`, `@ExportIgnore()` — decorator-based export API
- `buildExportFromEntity()` + 4 new `ExcelService` entity methods
- Full inheritance support for decorator columns

### Storage Drivers
- `StorageDriver` interface with `put()`, `get()`, `delete()`, `exists()`
- **LocalDriver** — local filesystem (default, zero-config)
- **S3Driver** — AWS S3 + S3-compatible services (MinIO, R2, DigitalOcean Spaces)
- **GCSDriver** — Google Cloud Storage
- **AzureDriver** — Azure Blob Storage
- **DiskManager** — injectable service for named storage backends
- Three credential strategies: SDK defaults, inline config, pre-configured client injection
- All cloud SDKs are optional peer dependencies
- Path traversal protection on LocalDriver
- Async I/O (non-blocking) on LocalDriver

### Test Coverage
- **234 tests**, all passing
- **99.33% statements, 100% functions, 100% lines**

## Test plan
- [x] All 234 tests pass
- [x] Coverage ≥ 99%
- [x] CHANGELOG updated for v0.3.0
- [x] README reflects new features and `disk` parameter
- [x] package.json version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)